### PR TITLE
NH-71775 Interpret DateTime/DateTime64 values of 0 as Jan 1 1970

### DIFF
--- a/proto/datetime.go
+++ b/proto/datetime.go
@@ -15,9 +15,6 @@ func ToDateTime(t time.Time) DateTime {
 
 // Time returns DateTime as time.Time.
 func (d DateTime) Time() time.Time {
-	if d == 0 {
-		return time.Time{}
-	}
 	// https://clickhouse.com/docs/en/sql-reference/data-types/datetime/#usage-remarks
 	// ClickHouse stores UTC timestamps that are timezone-agnostic.
 	return time.Unix(int64(d), 0)

--- a/proto/datetime64.go
+++ b/proto/datetime64.go
@@ -57,9 +57,6 @@ func ToDateTime64(t time.Time, p Precision) DateTime64 {
 
 // Time returns DateTime64 as time.Time.
 func (d DateTime64) Time(p Precision) time.Time {
-	if d == 0 {
-		return time.Time{}
-	}
 	nsec := int64(d) * p.Scale()
 	return time.Unix(nsec/1e9, nsec%1e9)
 }


### PR DESCRIPTION
## Summary
This changes the decode of DateTime/DateTime64 0 values. Instead of decoding them as `time.Time{}`, i.e. the zero value of `time.Time{}`, they are decoded as `time.Unix(0, 0)`, i.e. the unix epoch timestamp.